### PR TITLE
剔除公共依赖

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,8 +36,8 @@ module.exports = function(grunt) {
             filter:function(filepath){
                 return true;
             },
-            publicdeps:[
-                "vendors/zepto.js"
+            publicdeps:[ // 例如:"vendors/zepto.js"
+              "vendors/zepto.js"
             ]
         },
         files: {
@@ -67,6 +67,6 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['clean', 'lithe', 'nodeunit']);
 
   // By default, lint and run all tests.
-  grunt.registerTask('default', ['test']);
+  grunt.registerTask('default', ['jshint', 'test']);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,10 @@ module.exports = function(grunt) {
             basepath:'test/',
             filter:function(filepath){
                 return true;
-            }
+            },
+            publicdeps:[
+                "vendors/zepto.js"
+            ]
         },
         files: {
           'test/tmp/': 'test/conf/',
@@ -64,6 +67,6 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['clean', 'lithe', 'nodeunit']);
 
   // By default, lint and run all tests.
-  grunt.registerTask('default', ['jshint', 'test']);
+  grunt.registerTask('default', ['test']);
 
 };

--- a/tasks/lithe.js
+++ b/tasks/lithe.js
@@ -39,8 +39,15 @@ module.exports = function(grunt) {
 
 		// 改动,判断是否配置publicdeps
 
-		if (options.publicdeps && options.publicdeps.length > 0) {
-			litheOptions.publicdeps = options.publicdeps;
+		if (options.publicdeps) {
+			var deps = Object.keys(options.publicdeps);
+			litheOptions.publicdeps = tool.uniq(deps.map(function(current){
+				if (current.lastIndexOf(".js") < 0) {
+					return current + ".js";
+				}else {
+					return current;
+				}
+			}));
 		}
 
 		this.files.forEach(function(f) {
@@ -74,6 +81,7 @@ module.exports = function(grunt) {
 				requires.push(conf);
 
 				// 改动,剔除公共依赖
+
 				if (litheOptions.publicdeps) {
 					litheOptions.publicdeps.forEach(function(pd) {
 						requires.forEach(function(rd) {
@@ -84,9 +92,9 @@ module.exports = function(grunt) {
 					});
 				}
 
-				requires.forEach(function(current) {
+				/*requires.forEach(function(current) {
 					console.log("after...",current);
-				});
+				});*/
 
 				var str = requires.map(function(file) {
 					return grunt.file.read(file);

--- a/tasks/lithe.js
+++ b/tasks/lithe.js
@@ -37,6 +37,12 @@ module.exports = function(grunt) {
 			litheOptions.alias = options.alias;
 		}
 
+		// 改动,判断是否配置publicdeps
+
+		if (options.publicdeps && options.publicdeps.length > 0) {
+			litheOptions.publicdeps = options.publicdeps;
+		}
+
 		this.files.forEach(function(f) {
 			var src = [];
 			f.src.filter(function(path) {
@@ -66,6 +72,22 @@ module.exports = function(grunt) {
 				var conf = Path.resolve(rootpath, file.path);
 				var requires = tool.findJsAllrequires(conf,[],options.filter);
 				requires.push(conf);
+
+				// 改动,剔除公共依赖
+				if (litheOptions.publicdeps) {
+					litheOptions.publicdeps.forEach(function(pd) {
+						requires.forEach(function(rd) {
+							if (rd.replace(pd,"").length !== rd.length) {
+								requires.splice(requires.indexOf(rd),1);
+							}
+						});
+					});
+				}
+
+				requires.forEach(function(current) {
+					console.log("after...",current);
+				});
+
 				var str = requires.map(function(file) {
 					return grunt.file.read(file);
 				}).join('');


### PR DESCRIPTION
1.在Gruntfile的lithe的options增加publicdeps数组属性，值为公共依赖模块
2.在lithe.js中增加对publicdeps属性的判断，并增加对公共依赖的剥离
