### PR TITLE
修正windows文件路径

### DIFF
--- a/tasks/lithe.js
+++ b/tasks/lithe.js
@@ -80,6 +80,9 @@ module.exports = function(grunt) {
 				var requires = tool.findJsAllrequires(conf,[],options.filter);
 				requires.push(conf);
 
+				requires = requires.map(function(c) {
+					return c.split(Path.sep).join('/');
+				});
 				// 改动,剔除公共依赖
 
 				if (litheOptions.publicdeps) {


### PR DESCRIPTION
windows下文件路径是反斜杠，修正为斜杠，用来和lithe中定义的mod匹配
